### PR TITLE
Correct GitHub organisation

### DIFF
--- a/index.md
+++ b/index.md
@@ -26,7 +26,7 @@ Below are products and companies that uphold the standards defined in Microservi
 
 [![Asyncy](https://avatars0.githubusercontent.com/u/34162468?s=100&v=4 "Asyncy")](https://asyncy.com)
 
-> Add your company or product. Contact us below or make a [pull request](https://github.com/microservice.guide/microservice.guide).
+> Add your company or product. Contact us below or make a [pull request](https://github.com/microservice-guide/microservice.guide).
 
 ## Contact
 

--- a/package.json
+++ b/package.json
@@ -9,13 +9,13 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/microservice.guide/microservice.guide.git"
+    "url": "git+https://github.com/microservice-guide/microservice.guide.git"
   },
   "author": "",
   "bugs": {
-    "url": "https://github.com/microservice.guide/microservice.guide/issues"
+    "url": "https://github.com/microservice-guide/microservice.guide/issues"
   },
-  "homepage": "https://github.com/microservice.guide/microservice.guide#readme",
+  "homepage": "https://github.com/microservice-guide/microservice.guide#readme",
   "devDependencies": {
     "markdown-it-highlightjs": "^3.0.0",
     "vuepress": "github:vuejs/vuepress"


### PR DESCRIPTION
All the GitHub referenced links were pointing to nowhere, so I updated the dots to hyphens.